### PR TITLE
Add CI tasks for creating commit statuses on GitHub

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,0 +1,1 @@
+rvm use 1.9.2-p290@dice_bag --create

--- a/README.md
+++ b/README.md
@@ -83,6 +83,6 @@ be revoked from there.
 
 ## Owners
 
-* Andrew Smith  asmith@mdsol.com
-* Jordi Polo  jcarres@mdsol.com
+* [Andrew Smith](mailto:asmith@mdsol.com)
+* [Jordi Polo](mailto:jcarres@mdsol.com)
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,35 @@ namespaces:
 [bundle exec] rake -T
 ```
 
+### Setting commit status in GitHub
+
+The main `ci` task will update the current `HEAD` commit in the associated
+GitHub repo. To do so, a [GitHub OAuth][go] authorization token is required and
+must be provided in the `GITHUB_AUTH_TOKEN` environment variable, for example:
+
+[go]: http://developer.github.com/v3/oauth/
+
+```
+[bundle exec] rake GITHUB_AUTH_TOKEN=123... ci
+```
+
+CI servers like Jenkins let you set system-wide environment variables, saving
+the need of specifying this in every job. The status update is skipped if no
+token is provided.
+
+Create an authorization token with the following command:
+
+```
+curl -u <username> -d '{"scopes":["repo:status"],"note":"CI status updater"}' https://api.github.com/authorizations
+```
+
+You will be prompted for your GitHub account password.
+
+The token is restricted to updating commit status only. The token is associated
+to the given user, as are any commit statuses created using it. The note given
+is the display name used in the GitHub account management pages and tokens can
+be revoked from there.
+
 ## TODO
 
 * Describe the template-and-environment-driven processing here.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ to the given user, as are any commit statuses created using it. The note given
 is the display name used in the GitHub account management pages and tokens can
 be revoked from there.
 
+The commit status created uses the `BUILD_NUMBER` and `BUILD_URL` environment
+variables as [provided by Jenkins][je]. Alternatively, these can be provided or
+overridden on the command line, for example:
+
+```
+[bundle exec] rake BUILD_NUMBER=$MY_BUILD_NUM BUILD_URL=http://example.com/url ci
+```
+
+[je]: https://wiki.jenkins-ci.org/display/JENKINS/Building+a+software+project#Buildingasoftwareproject-JenkinsSetEnvironmentVariables
+
 ## TODO
 
 * Describe the template-and-environment-driven processing here.

--- a/lib/dice_bag/github.rb
+++ b/lib/dice_bag/github.rb
@@ -1,0 +1,53 @@
+require 'net/https'
+
+module DiceBag
+
+  # This module abstracts access to GitHub. It's current purpose is solely to
+  # allow commit statuses to be updated.
+  #
+  # See: https://github.com/blog/1227-commit-status-api
+  #
+  module GitHub
+    extend self
+
+    def update_commit_status(state, config)
+
+      # TODO: Refactor the following code to use gems like git/grit/rugged and
+      # octokit. The reason this code does not do this currently is to avoid
+      # introducing these gems as unnecessary dependencies for production
+      # deployment, which is a target for Dice Bag. The plan is to split the CI
+      # tasks out from this gem so they can pull in development and test
+      # dependencies freely. ~asmith
+
+      body = %Q({
+        "state": "#{state}",
+        "target_url": "#{config.build_url}",
+        "description": "Continuous integration run #{config.build_number}"
+      })
+      commit = `git log -1 --format=format:%H`
+      remotes = `git remote --verbose`
+
+      unless repo = /^origin\s+git@github.com:(\w+\/\w+)\b/.match(remotes)[1]
+        put "Could not establish GitHub repo name from 'origin' remote"
+        return
+      end
+
+      uri = URI("https://api.github.com/repos/#{repo}/statuses/#{commit}?access_token=#{config.github_auth_token}")
+
+      if config.github_auth_token
+        puts "Setting #{repo} commit #{commit} status to '#{state}' on GitHub"
+      else
+        puts "Skipping setting #{repo} commit #{commit} status to '#{state}' on GitHub because access token not configured"
+        return
+      end
+
+      Net::HTTP.start(uri.host, uri.port, :use_ssl => true) do |http|
+        response = http.post(uri.request_uri, body)
+        unless response.is_a?(Net::HTTPCreated)
+          puts "Setting commit status FAILED", response
+        end
+      end
+    end
+  end
+end
+

--- a/lib/dice_bag/github.rb
+++ b/lib/dice_bag/github.rb
@@ -10,6 +10,12 @@ module DiceBag
   module GitHub
     extend self
 
+    # Update the commit status for the current HEAD commit. Assumes the working
+    # directory is a git repo and the "origin" remote points to a GitHub repo.
+    # The +state+ variable must be one of :pending, :success or :failure. The
+    # +config+ object must respond to +build_number+, +build_url+ and
+    # +github_auth_token+.
+    #
     def update_commit_status(state, config)
 
       # TODO: Refactor the following code to use gems like git/grit/rugged and
@@ -20,7 +26,7 @@ module DiceBag
       # dependencies freely. ~asmith
 
       body = %Q({
-        "state": "#{state}",
+        "state": "#{state.to_s}",
         "target_url": "#{config.build_url}",
         "description": "Continuous integration run #{config.build_number}"
       })

--- a/lib/dice_bag/tasks/ci.rake
+++ b/lib/dice_bag/tasks/ci.rake
@@ -1,9 +1,8 @@
 desc "Configure and run continuous integration tests then clean up"
-task :ci do 
+task :ci do
   begin
     Rake::Task["ci:config"].invoke
     Rake::Task["ci:run"].invoke
-    Rake::Task["ci:clean"].invoke
   ensure
     Rake::Task["ci:clean"].invoke
   end

--- a/lib/dice_bag/tasks/ci.rake
+++ b/lib/dice_bag/tasks/ci.rake
@@ -1,10 +1,13 @@
 require 'dice_bag/github'
 
 desc "Configure and run continuous integration tests then clean up"
-task :ci do
+task :ci => ['ci:status:pending'] do
   begin
     Rake::Task["ci:config"].invoke
     Rake::Task["ci:run"].invoke
+    Rake::Task["ci:status:success"].invoke
+  rescue
+    Rake::Task["ci:status:failure"].invoke
   ensure
     Rake::Task["ci:clean"].invoke
   end

--- a/lib/dice_bag/tasks/ci.rake
+++ b/lib/dice_bag/tasks/ci.rake
@@ -45,13 +45,13 @@ namespace :ci do
     config = DiceBag::Configuration.new
 
     task :pending do
-      DiceBag::GitHub.update_commit_status('pending', config)
+      DiceBag::GitHub.update_commit_status(:pending, config)
     end
     task :success do
-      DiceBag::GitHub.update_commit_status('success', config)
+      DiceBag::GitHub.update_commit_status(:success, config)
     end
     task :failure do
-      DiceBag::GitHub.update_commit_status('failure', config)
+      DiceBag::GitHub.update_commit_status(:failure, config)
     end
   end
 end

--- a/lib/dice_bag/tasks/ci.rake
+++ b/lib/dice_bag/tasks/ci.rake
@@ -1,3 +1,5 @@
+require 'dice_bag/github'
+
 desc "Configure and run continuous integration tests then clean up"
 task :ci do
   begin
@@ -33,6 +35,21 @@ namespace :ci do
   task :brakeman do
     # Make warnings fail the build with the '--exit-on-warn' switch.
     sh('bundle exec brakeman --quiet --exit-on-warn')
+  end
+
+  namespace :status do
+
+    config = DiceBag::Configuration.new
+
+    task :pending do
+      DiceBag::GitHub.update_commit_status('pending', config)
+    end
+    task :success do
+      DiceBag::GitHub.update_commit_status('success', config)
+    end
+    task :failure do
+      DiceBag::GitHub.update_commit_status('failure', config)
+    end
   end
 end
 


### PR DESCRIPTION
This change uses the GitHub commit status API to set the status of the latest commit dependent on the outcome of the `ci` task. Usage notes included in the README update.

Any of @jcarres-mdsol, @mszenher or @chad-medi to review, please.
