### PR TITLE
dice_bag carries template files in the bag

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ Run the following command to see the new tasks:
 [bundle exec] rake -D config
 ```
 
+## Define your own templates
+
+Read the [templates] file to know how to include your own template files
+in the generation mechanism of dice_bag
+
 ## Owners
 
 * [Andrew Smith](mailto:asmith@mdsol.com)

--- a/dice_bag.gemspec
+++ b/dice_bag.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |s|
   s.authors = ['Andrew Smith']
   s.email = ['asmith@mdsol.com']
   s.summary = 'Dice Bag is a library of rake tasks for configuring web apps in the style of The Twelve-Factor App. It also provides continuous integration tasks that rely on the configuration tasks.'
+  s.homepage = "https://github.com/mdsol/dice_bag"
 
   s.files = Dir['lib/**/*']
   s.test_files = Dir['spec/**/*']

--- a/lib/dice_bag.rb
+++ b/lib/dice_bag.rb
@@ -1,3 +1,4 @@
+require_relative 'dice_bag/available_templates'
 module DiceBag
   require 'dice_bag/railtie' if defined?(Rails)
 end

--- a/lib/dice_bag/available_templates.rb
+++ b/lib/dice_bag/available_templates.rb
@@ -3,21 +3,33 @@ module DiceBag
  
   class AvailableTemplates
 
-    def self.all
-      #all the classes than inherit from us in the ruby runtime
-      template_checkers = ObjectSpace.each_object(Class).select { |klass| klass < self }
-      available_templates = []
+    class << self
 
-      template_checkers.each do |checker|
-        checker.new.templates.each do |template|
-          available_templates.push( template)
-        end
+      def template_checkers
+        @template_checkers ||= []
       end
-      available_templates
+
+      def inherited(base)
+        template_checkers << base
+      end
+
+      def all
+        #all the classes than inherit from us in the ruby runtime
+        available_templates = []
+
+        template_checkers.each do |checker|
+          checker.new.templates.each do |template|
+            available_templates.push( template)
+          end
+        end
+        available_templates
+      end
     end
 
   end
+
 end
+
 
 # we require the our own templates checker here, for other gems we just need 
 # them to inherit from DiceBag::AvailableTemplates and require the file 

--- a/lib/dice_bag/available_templates.rb
+++ b/lib/dice_bag/available_templates.rb
@@ -1,4 +1,7 @@
-
+# This class returns all the templates we can generate in this particular project
+# It can read directories with templates.
+# These directories are self-contained, they contain both the templates and the 
+# code that decide if the templates should be generated for this project
 module DiceBag
   class AvailableTemplates
     @@available = []

--- a/lib/dice_bag/available_templates.rb
+++ b/lib/dice_bag/available_templates.rb
@@ -1,0 +1,27 @@
+
+module DiceBag
+  class AvailableTemplates
+    @@available = []
+
+    def self.all
+      self.read_dir(File.join(File.dirname(__FILE__), "templates/"))
+      @@available
+    end
+
+    def self.add(filename)
+      @@available.push(filename) 
+      @@available.flatten.uniq
+    end
+
+    def self.read_dir(dirname)
+      gem_file = File.join(dirname, 'gems_checker.rb')
+      require gem_file
+      DiceBag::needed_templates.each do |template|
+        filename = File.join(dirname, template)
+        self.add( filename )
+      end
+    end
+
+  end
+end
+

--- a/lib/dice_bag/available_templates.rb
+++ b/lib/dice_bag/available_templates.rb
@@ -1,30 +1,25 @@
 # This class returns all the templates we can generate in this particular project
-# It can read directories with templates.
-# These directories are self-contained, they contain both the templates and the 
-# code that decide if the templates should be generated for this project
 module DiceBag
+ 
   class AvailableTemplates
-    @@available = []
 
     def self.all
-      self.read_dir(File.join(File.dirname(__FILE__), "templates/"))
-      @@available
-    end
+      #all the classes than inherit from us in the ruby runtime
+      template_checkers = ObjectSpace.each_object(Class).select { |klass| klass < self }
+      available_templates = []
 
-    def self.add(filename)
-      @@available.push(filename) 
-      @@available.flatten.uniq
-    end
-
-    def self.read_dir(dirname)
-      gem_file = File.join(dirname, 'gems_checker.rb')
-      require gem_file
-      DiceBag::needed_templates.each do |template|
-        filename = File.join(dirname, template)
-        self.add( filename )
+      template_checkers.each do |checker|
+        checker.new.templates.each do |template|
+          available_templates.push( template)
+        end
       end
+      available_templates
     end
 
   end
 end
 
+# we require the our own templates checker here, for other gems we just need 
+# them to inherit from DiceBag::AvailableTemplates and require the file 
+# If Ruby loads the file we can find the class in the object space and call it
+require_relative 'templates/gems_checker'

--- a/lib/dice_bag/configuration.rb
+++ b/lib/dice_bag/configuration.rb
@@ -95,8 +95,14 @@ module DiceBag
   #utility methods used by the methods above, surely need to be moved somewhere else.
   
   def self.copy_file(src, dst)
-    #TODO: how to do this in no-rails environments?
-    project_name = Rails.application.class.parent_name.downcase
+    if defined?(Rails)
+      project_name = Rails.application.class.parent_name.downcase
+    else
+    #TODO: how to do find the name of the project in no-rails environments?
+      project_name = 'project'
+    end
+    # Some templates need the name of the project. We put a placeholder
+    # PROJECT_NAME there, it gets substituted by the real name of the project here
     File.open(dst,"w") do |output|
       output.puts File.readlines(src).join.gsub("PROJECT_NAME", project_name)
     end

--- a/lib/dice_bag/configuration.rb
+++ b/lib/dice_bag/configuration.rb
@@ -111,12 +111,8 @@ module DiceBag
   end
 
   def self.project_name
-    if defined?(Rails)
-      project_name = Rails.application.class.parent_name.downcase
-    else
     #TODO: how to do find the name of the project in no-rails environments?
-      project_name = 'project'
-    end
+    defined?(Rails) ? Rails.application.class.parent_name.downcase : 'project'
   end
 
 end

--- a/lib/dice_bag/configuration.rb
+++ b/lib/dice_bag/configuration.rb
@@ -104,8 +104,8 @@ module DiceBag
 
   #TODO: Find a better home for this method
   def self.configuration_dir
-    #TODO: properly find the root of the project in non rails projects.
-    root = defined?(Rails) ? Rails.root : Dir.pwd 
-    File.join(root, "config")
+    # Dir.pwd is the directory that contains the Rakefile. 
+    # We may want to make this more general in the future
+    File.join(Dir.pwd, "config")
   end
 end

--- a/lib/dice_bag/configuration.rb
+++ b/lib/dice_bag/configuration.rb
@@ -91,6 +91,9 @@ module DiceBag
 
   end
 
+
+  #utility methods used by the methods above, surely need to be moved somewhere else.
+  
   def self.copy_file(src, dst)
     #TODO: how to do this in no-rails environments?
     project_name = Rails.application.class.parent_name.downcase

--- a/lib/dice_bag/configuration.rb
+++ b/lib/dice_bag/configuration.rb
@@ -66,6 +66,7 @@ module DiceBag
       # like mauth_key where we want to control newlines carefully.
       template = ERB.new(File.read(template_filename), nil, "<>")
 
+      #templates expect a configured object
       configured = Configuration.new
       File.open(config_filename, 'w') {|file| file.puts(template.result(binding)) }
     end
@@ -95,16 +96,10 @@ module DiceBag
   #utility methods used by the methods above, surely need to be moved somewhere else.
   
   def self.copy_file(src, dst)
-    if defined?(Rails)
-      project_name = Rails.application.class.parent_name.downcase
-    else
-    #TODO: how to do find the name of the project in no-rails environments?
-      project_name = 'project'
-    end
     # Some templates need the name of the project. We put a placeholder
     # PROJECT_NAME there, it gets substituted by the real name of the project here
     File.open(dst,"w") do |output|
-      output.puts File.readlines(src).join.gsub("PROJECT_NAME", project_name)
+      output.puts File.readlines(src).join.gsub("PROJECT_NAME", self.project_name)
     end
   end
 
@@ -114,4 +109,14 @@ module DiceBag
     # We may want to make this more general in the future
     File.join(Dir.pwd, "config")
   end
+
+  def self.project_name
+    if defined?(Rails)
+      project_name = Rails.application.class.parent_name.downcase
+    else
+    #TODO: how to do find the name of the project in no-rails environments?
+      project_name = 'project'
+    end
+  end
+
 end

--- a/lib/dice_bag/tasks/config.rake
+++ b/lib/dice_bag/tasks/config.rake
@@ -19,4 +19,15 @@ namespace :config do
     DiceBag::Configuration.write(filename)
   end
 
+  desc "Generates all the template files needed by this project, named as the parameter"
+  task :generate_all do
+    DiceBag::Configuration.generate_all_templates
+  end
+
+  desc "Regenerate a given template"
+  task :generate, :filename do |t, args|
+    filename = args[:filename]
+    raise "A filename needs to be provided" if filename.nil?
+    DiceBag::Configuration.generate_template(filename)
+  end
 end

--- a/lib/dice_bag/templates/aws.yml.erb
+++ b/lib/dice_bag/templates/aws.yml.erb
@@ -5,8 +5,8 @@
 # production deployment. ~asmith
 %>
 development: &default
-  access_key_id: <%= configured.aws_access_key_id || '' %>
-  secret_access_key: <%= configured.aws_secret_access_key || '' %>
+  access_key_id: <%= configured.aws_access_key_id  %>
+  secret_access_key: <%= configured.aws_secret_access_key  %>
 
 test:
   <<: *default

--- a/lib/dice_bag/templates/aws.yml.erb
+++ b/lib/dice_bag/templates/aws.yml.erb
@@ -1,0 +1,12 @@
+<%
+# TODO: Replace the settings below with values from the environment, as per the
+# 'mauth.yml.erb' template. Not doing this now as it's not required for running
+# tests locally or in the CI environment; would be required for use in
+# production deployment. ~asmith
+%>
+development: &default
+  access_key_id: XXXXXXXXXXXXXXXXXXXX
+  secret_access_key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+test:
+  <<: *default

--- a/lib/dice_bag/templates/aws.yml.erb
+++ b/lib/dice_bag/templates/aws.yml.erb
@@ -5,8 +5,8 @@
 # production deployment. ~asmith
 %>
 development: &default
-  access_key_id: XXXXXXXXXXXXXXXXXXXX
-  secret_access_key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  access_key_id: <%= configured.aws_access_key_id || '' %>
+  secret_access_key: <%= configured.aws_secret_access_key || '' %>
 
 test:
   <<: *default

--- a/lib/dice_bag/templates/dalli.yml.erb
+++ b/lib/dice_bag/templates/dalli.yml.erb
@@ -1,0 +1,15 @@
+<%= "# This example file is intended to be used by a the developer who would like
+# use a locally running memcached.  By default, though, 
+# config/environments/development.rb sets the cache_store to memory
+# To enable this storage mechanism in development mode, consult the 
+# cache configuration code in config/environments/production.rb
+" %>
+development: &default
+  namespace: PROJECT_NAME
+  host: localhost
+  port: 11211
+  value_max_bytes: 52428800
+  compress: true
+  
+test:
+  <<: *default

--- a/lib/dice_bag/templates/database.yml.erb
+++ b/lib/dice_bag/templates/database.yml.erb
@@ -1,6 +1,6 @@
 <% [:development, :test, :production].each do |env| %>
 <%= env %>:
-  adapter: mysql2
+  adapter: <%= configured[env].database_driver || 'mysql2' %>
   database: <%= configured[env].database_name || "PROJECT_NAME_#{env}" %>
   username: <%= configured[env].database_username || 'root' %>
   password: <%= configured[env].database_password %>

--- a/lib/dice_bag/templates/database.yml.erb
+++ b/lib/dice_bag/templates/database.yml.erb
@@ -1,0 +1,9 @@
+<% [:development, :test, :production].each do |env| %>
+<%= env %>:
+  adapter: mysql2
+  database: <%= configured[env].database_name || "PROJECT_NAME_#{env}" %>
+  username: <%= configured[env].database_username || 'root' %>
+  password: <%= configured[env].database_password %>
+  pool: 5
+  timeout: 5000
+<% end %>

--- a/lib/dice_bag/templates/database.yml.erb
+++ b/lib/dice_bag/templates/database.yml.erb
@@ -4,6 +4,9 @@
   database: <%= configured[env].database_name || "PROJECT_NAME_#{env}" %>
   username: <%= configured[env].database_username || 'root' %>
   password: <%= configured[env].database_password %>
+  host: <%= configured[env].database_host || 'localhost' %>
+  <% db_cert = configured[env].database_ssl_cert %>
+  <%= db_cert ? "sslca: #{db_cert}" : '' %>
   pool: 5
   timeout: 5000
 <% end %>

--- a/lib/dice_bag/templates/gems_checker.rb
+++ b/lib/dice_bag/templates/gems_checker.rb
@@ -18,6 +18,10 @@ module DiceBag
     if configured.google_analytics_id
       needed_templates.push('google_analytics.yml.erb')
     end
+    
+    if defined?(NewRelic)
+      needed_templates.push('newrelic.yml.erb')
+    end
 
     needed_templates
   end

--- a/lib/dice_bag/templates/gems_checker.rb
+++ b/lib/dice_bag/templates/gems_checker.rb
@@ -2,31 +2,43 @@
 # generated for this project.
 # this file lives in the same directory than all the templates it
 # provides logic for.
+require 'dice_bag'
+
 module DiceBag
-  def self.needed_templates
-    needed_templates = []
-    configured = Configuration.new
-
-    if defined?(Dalli)
-      needed_templates.push('dalli.yml.erb')
-    end
-
-    if defined?(Mysql2)
-      needed_templates.push('database.yml.erb')
-    end
-
-    if defined?(AWS)
-      needed_templates.push('aws.yml.erb')
-    end
-
-    if configured.google_analytics_id
-      needed_templates.push('google_analytics.yml.erb')
-    end
+  class CommonTemplatesBag < AvailableTemplates 
     
-    if defined?(NewRelic)
-      needed_templates.push('newrelic.yml.erb')
+    def templates
+      @needed_templates = []
+      configured = Configuration.new
+
+      if defined?(Dalli)
+        add_template('dalli.yml.erb')
+      end
+
+      if defined?(Mysql2)
+        add_template('database.yml.erb')
+      end
+
+      if defined?(AWS)
+        add_template('aws.yml.erb')
+      end
+
+      if configured.google_analytics_id
+        add_template('google_analytics.yml.erb')
+      end
+      
+      if defined?(NewRelic)
+        add_template('newrelic.yml.erb')
+      end
+
+      @needed_templates
     end
 
-    needed_templates
+    def add_template(file)
+      pwd = File.dirname(__FILE__)
+      @needed_templates.push(File.join(pwd, file))
+    end 
+
   end
+  
 end

--- a/lib/dice_bag/templates/gems_checker.rb
+++ b/lib/dice_bag/templates/gems_checker.rb
@@ -1,3 +1,7 @@
+# This module has the logic that decides what templates will be
+# generated for this project.
+# this file lives in the same directory than all the templates it
+# provides logic for.
 module DiceBag
   def self.needed_templates
     needed_templates = []

--- a/lib/dice_bag/templates/gems_checker.rb
+++ b/lib/dice_bag/templates/gems_checker.rb
@@ -26,7 +26,7 @@ module DiceBag
       if configured.google_analytics_id
         add_template('google_analytics.yml.erb')
       end
-      
+
       if defined?(NewRelic)
         add_template('newrelic.yml.erb')
       end
@@ -40,5 +40,5 @@ module DiceBag
     end 
 
   end
-  
+
 end

--- a/lib/dice_bag/templates/gems_checker.rb
+++ b/lib/dice_bag/templates/gems_checker.rb
@@ -1,0 +1,19 @@
+module DiceBag
+  def self.needed_templates
+    needed_templates = []
+
+    if defined?(Dalli)
+      needed_templates.push('dalli.yml.erb')
+    end
+
+    if defined?(Mysql2)
+      needed_templates.push('database.yml.erb')
+    end
+
+    if defined?(AWS)
+      needed_templates.push('aws.yml.erb')
+    end
+
+    needed_templates
+  end
+end

--- a/lib/dice_bag/templates/gems_checker.rb
+++ b/lib/dice_bag/templates/gems_checker.rb
@@ -1,6 +1,7 @@
 module DiceBag
   def self.needed_templates
     needed_templates = []
+    configured = Configuration.new
 
     if defined?(Dalli)
       needed_templates.push('dalli.yml.erb')
@@ -12,6 +13,10 @@ module DiceBag
 
     if defined?(AWS)
       needed_templates.push('aws.yml.erb')
+    end
+
+    if configured.google_analytics_id
+      needed_templates.push('google_analytics.yml.erb')
     end
 
     needed_templates

--- a/lib/dice_bag/templates/google_analytics.yml.erb
+++ b/lib/dice_bag/templates/google_analytics.yml.erb
@@ -1,0 +1,3 @@
+<% if configured.google_analytics_id %>
+<%= "#{configured.rails_env}: #{configured.google_analytics_id}" %>
+<% end %>

--- a/lib/dice_bag/templates/newrelic.yml.erb
+++ b/lib/dice_bag/templates/newrelic.yml.erb
@@ -1,6 +1,6 @@
 common: &default_settings
   license_key: <%= configured.newrelic_key || "12345" %>
-  app_name: <%= configured.domain || PROJECT_NAME %>
+  app_name: <%= configured.domain || 'PROJECT_NAME' %>
   enabled: <%= configured.enable_newrelic || false %>
   log_level: <%= configured.new_relic_debug == 'true' ? 'debug' : 'info' %>
   ssl: false

--- a/lib/dice_bag/templates/newrelic.yml.erb
+++ b/lib/dice_bag/templates/newrelic.yml.erb
@@ -17,6 +17,6 @@ common: &default_settings
     ignore_errors: ActionController::RoutingError
   background:
     monitor_mode: true
-    app_name: <%= configured.domain || PROJECT_NAME %>
+    app_name: <%= configured.domain || 'PROJECT_NAME' %>
 <%= configured.rails_env %>
   <<: *default_settings

--- a/lib/dice_bag/templates/newrelic.yml.erb
+++ b/lib/dice_bag/templates/newrelic.yml.erb
@@ -1,0 +1,22 @@
+common: &default_settings
+  license_key: <%= configured.newrelic_key || "12345" %>
+  app_name: <%= configured.domain || PROJECT_NAME %>
+  enabled: <%= configured.enable_newrelic || false %>
+  log_level: <%= configured.new_relic_debug == 'true' ? 'debug' : 'info' %>
+  ssl: false
+  apdex_t: 0.5
+  capture_params: false
+  transaction_tracer:
+    enabled: true
+    transaction_threshold: apdex_f
+    record_sql: obfuscated
+    stack_trace_threshold: <%= configured.new_relic_debug == 'true' ? '0.1' : '0.5' %>
+  error_collector:
+    enabled: true
+    capture_source: true
+    ignore_errors: ActionController::RoutingError
+  background:
+    monitor_mode: true
+    app_name: <%= configured.domain || PROJECT_NAME %>
+<%= configured.rails_env %>
+  <<: *default_settings

--- a/templates.md
+++ b/templates.md
@@ -1,0 +1,27 @@
+## Define your own templates
+
+Dice bag comes with templates for common configuration files.
+You can execute:
+```ruby
+rake config:generate_all
+```
+to generate templates for the configuration files of your project.
+
+If you want to add your own templates to be generated with this command
+you can create your own gem or a file in your project where you have a
+class inheriting from DiceBag::AvailableTemplates.
+This class will have a method called templates.
+This method returns an array of strings. Each string will
+be the full path location of one template.
+Example:
+
+```ruby
+class MyTemplates << Dicebag::AvailableTemplates
+  def templates
+    all_templates = []
+    pwd = File.dirname(__FILE__)
+    all_templates.push(File.join(pwd, "my_template.yml.erb))
+    all_templates
+  end
+end
+```


### PR DESCRIPTION
This tries to address one of the issues of dice_bag
it creates a new task to generate the template files and some common template files. 
Some problems are still unresolved, most importantly, how to include medidata specific files in a second gem and get them installed also. 
The read dir method is supposed to be general enough to read from other directories so the 'intelligence' of what files are needed is also written in the directory we read, the gems_needed.rb file.
