### PR TITLE
delete deprecated railties name

### DIFF
--- a/lib/dice_bag/railtie.rb
+++ b/lib/dice_bag/railtie.rb
@@ -1,7 +1,5 @@
 module DiceBag
   class Railtie < Rails::Railtie
-    railtie_name :dice_bag
-
     rake_tasks do
       require 'dice_bag/tasks'
     end


### PR DESCRIPTION
Address  issue #27
It seems that we just delete it and that is fine 
Thanks @harryw for reporting
