### PR TITLE
added run task

### DIFF
--- a/lib/dice_bag/tasks/config.rake
+++ b/lib/dice_bag/tasks/config.rake
@@ -29,3 +29,13 @@ namespace :config do
     DiceBag::Command.new.generate_template(filename)
   end
 end
+
+desc "Runs the server"
+task :run do
+  port = ENV['PORT'] || 3000
+  if defined?(Rails)
+    `bundle exec rails server -p #{port}`
+  elsif defined?(Sinatra)
+    `bundle exec rackup -p #{port}`
+  end
+end


### PR DESCRIPTION
Added a run task, useful in automated environments like deploy or shadowfax where we do not want to standarize the process.

As rake load all the gems and then calling the command to launch the server load them again, calling this takes like twice the time it would take calling the command directly.

I tried to make it work for rails , this works till where rails try to know what command we want:
    load Gem.bin_path('rails', 'rails', ">= 0")
    APP_PATH = File.join(pwd, 'config/application')
    require 'rails/commands'

As rails parse with Optparser the ARGV and there is no command there it fails, I've tried to modify ARGV and seems to not be possible. I guess I am very close to a solution here. Anyway first wanted to do this PR to see it the idea itself is worthy and if we care about those extra seconds at startup or not. I would care.
