### PR TITLE
added reconnect false to DB template

### DIFF
--- a/lib/dice_bag/templates/database.yml.erb
+++ b/lib/dice_bag/templates/database.yml.erb
@@ -8,6 +8,7 @@
   pool: 5
   timeout: 5000
   encoding: utf8
+  reconnect: false
   <% db_cert = configured[env].database_ssl_cert %>
   <%= db_cert ? "sslca: #{db_cert}" : '' %>
 <% end %>


### PR DESCRIPTION
reconnect: false is the default in both ruby and the c client library but just in case make it explicit.
