### PR TITLE
restored support to generating specific templates

### DIFF
--- a/lib/dice_bag/available_templates.rb
+++ b/lib/dice_bag/available_templates.rb
@@ -24,6 +24,14 @@ module DiceBag
         end
         available_templates
       end
+
+      def template_filename_for(filename)
+        self.all.each do |template_filename|
+          if template_filename.include? filename
+            return template_filename
+          end
+        end
+      end
     end
 
   end

--- a/lib/dice_bag/default_template_file.rb
+++ b/lib/dice_bag/default_template_file.rb
@@ -10,6 +10,10 @@ module DiceBag
     include DiceBagFile
 
     def initialize(name)
+      #if called from command line with only a name we search in all our templates for the file
+      if (File.dirname(name) == '.')
+        name = AvailableTemplates.template_filename_for(name)
+      end
       @filename = File.basename(name)
       @file = name
     end


### PR DESCRIPTION
rake generate[database.yml.erb] to generate only this template. 
config:all only looks at the templates in your config/ so it is safe, you can do:
rake config:file[database.yml] if you are paranoid.

We were supposed to have this working before but I broke it and didnt realize, we need tests...

I think this should address #35 , @harryw, please tell me if this is what you need.
