### PR TITLE
Add production keys to aws and dalli config templates

### DIFF
--- a/lib/dice_bag/templates/aws.yml.erb
+++ b/lib/dice_bag/templates/aws.yml.erb
@@ -10,3 +10,5 @@ development: &default
 
 test:
   <<: *default
+production:
+  <<: *default

--- a/lib/dice_bag/templates/dalli.yml.erb
+++ b/lib/dice_bag/templates/dalli.yml.erb
@@ -13,3 +13,6 @@ development: &default
   
 test:
   <<: *default
+
+production:
+  <<: *default


### PR DESCRIPTION
One tiny step towards dev/prod parity.  So long as these keys are here, Medistrano will cheerfully deploy the app.
