### PR TITLE
Add history documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# 0.4.0
+
+* Initial open source release.
+

--- a/README.md
+++ b/README.md
@@ -143,7 +143,10 @@ If you want DiceBag to generate your own pre-packaged templates when you run the
 rake `config:generate_all` task, you can create a plug-in. Read the
 `templates.md` file to learn how to do this.
 
-## Owners
+## Contributors
 
-* [Andrew Smith](mailto:asmith@mdsol.com)
-* [Jordi Carres](mailto:jcarres@mdsol.com)
+* [Andrew Smith](https://github.com/asmith-mdsol)
+* [Jordi Carres](https://github.com/jcarres-mdsol)
+* [Dan Hoizner](https://github.com/dhoizner-mdsol)
+* [Aaron Weiner](https://github.com/HonoreDB)
+

--- a/lib/dice_bag/version.rb
+++ b/lib/dice_bag/version.rb
@@ -1,3 +1,3 @@
 module DiceBag
-  VERSION = '0.3.0'
+  VERSION = '0.4.0'
 end


### PR DESCRIPTION
Adds history documentation and bumps version to signify open sourcing of the project. Also updates the README to include contributors-to-date.
