### PR TITLE
Feature/rails goes to config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.1
+
+* Bugfix: templates are generated in config/ for Rails projects
+
 # 0.4.0
 
 * Initial open source release.

--- a/lib/dice_bag/config_file.rb
+++ b/lib/dice_bag/config_file.rb
@@ -8,7 +8,7 @@ module DiceBag
     include DiceBagFile
     def initialize(name)
       @filename = name.gsub('.local', '').gsub('.erb', '').gsub('.template','')
-      @file = @filename
+      @file = Project.config_files(@filename)
     end
   end
 end

--- a/lib/dice_bag/project.rb
+++ b/lib/dice_bag/project.rb
@@ -27,7 +27,7 @@ module DiceBag
       all_files = generated_templates + custom_templates
       cleaned_templates = all_files.delete_if {|file| custom_templates.include?(file + '.local')}
       dotNetTemplates = dotNetTemplates.delete_if {|file| file.include?("/bin/")}
-      cleaned_templates + dotNetTemplates
+      (cleaned_templates + dotNetTemplates).map { |template| File.basename(template) }
     end
 
   end

--- a/lib/dice_bag/project.rb
+++ b/lib/dice_bag/project.rb
@@ -10,18 +10,25 @@ module DiceBag
     end
 
     def self.config_files(filename)
-      File.join(Dir.pwd, filename)
+      File.join(self.config_dir, filename)
+    end
+
+    # dotNet apps do not have the templates in config/ but in the root of the project
+    # TODO: detect dotNet instead of detecting rails
+    def self.config_dir
+      defined?(Rails) ? File.join(Dir.pwd, 'config') : Dir.pwd
     end
 
     #local templates always takes preference over generated templates
     def self.templates_to_generate
-      generated_templates = Dir[Project.config_files("**/config/*.erb")]
-      custom_templates = Dir[Project.config_files("**/config/*.erb.local")]
+      generated_templates = Dir[Project.config_files("**/*.erb")]
+      custom_templates = Dir[Project.config_files("**/*.erb.local")]
       dotNetTemplates = Dir[Project.config_files("**/*.config.template")]
       all_files = generated_templates + custom_templates
-      templates = all_files.delete_if {|file| custom_templates.include?(file + '.local')}
+      cleaned_templates = all_files.delete_if {|file| custom_templates.include?(file + '.local')}
       dotNetTemplates = dotNetTemplates.delete_if {|file| file.include?("/bin/")}
-      all_files + dotNetTemplates
+      cleaned_templates + dotNetTemplates
     end
+
   end
 end

--- a/lib/dice_bag/template_file.rb
+++ b/lib/dice_bag/template_file.rb
@@ -16,7 +16,7 @@ module DiceBag
 
     def initialize(name)
       @filename = File.basename(name)
-      @file = name
+      @file = Project.config_files(name)
     end
 
     def create_file(config_file)

--- a/lib/dice_bag/template_file.rb
+++ b/lib/dice_bag/template_file.rb
@@ -32,7 +32,7 @@ module DiceBag
 
       return unless config_file.should_write?(contents)
       config_file.write(contents)
-      puts "file #{config_file.file} created"
+      puts "file #{Project.config_dir}/#{config_file.file} created"
     end
 
   end

--- a/lib/dice_bag/version.rb
+++ b/lib/dice_bag/version.rb
@@ -1,3 +1,3 @@
 module DiceBag
-  VERSION = '0.4.0'
+  VERSION = '0.4.1'
 end


### PR DESCRIPTION
This is a bugfix.

Aaron found a bug, a serious bug. Since we merged the dotnet support we are generating our files in the root directory of any app instead of config/

The main change is that now we have a  Project.config_dir which will select config/ or root depending on the type of app.
It now only support Rails vs non-Rails , the ideal would be to support dotNet vs non-dotNet, if you know how to detect dotnet projects please enlighten me.

We can also do something like if there is a 'config' directory then use it, else go for the root. I do not know if dotnet have some misleading 'config' directory though.

@asmith-mdsol  please review
