### PR TITLE
Add scenario testing infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # We're a library, so we avoid overly constraining clients.
 Gemfile.lock
+
+# Temporary files such as those created by aruba when running scenarios.
+/tmp

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Locally built gem files.
+*.gem
+
+# We're a library, so we avoid overly constraining clients.
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem 'pry'

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/dice_bag.gemspec
+++ b/dice_bag.gemspec
@@ -5,8 +5,8 @@ Gem::Specification.new do |s|
   s.version = DiceBag::VERSION
   s.platform = Gem::Platform::RUBY
 
-  s.authors = ['Andrew Smith']
-  s.email = ['asmith@mdsol.com']
+  s.authors = ['Andrew Smith', 'Jordi Carres']
+  s.email = ['asmith@mdsol.com', 'jcarres@mdsol.com']
   s.summary = 'Dice Bag is a library of rake tasks for configuring web apps in the style of The Twelve-Factor App. It also provides continuous integration tasks that rely on the configuration tasks.'
   s.homepage = "https://github.com/mdsol/dice_bag"
 
@@ -15,5 +15,6 @@ Gem::Specification.new do |s|
   s.executables = Dir['bin/*'].map{ |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_development_dependency "rspec"
+  s.add_development_dependency 'aruba', '~> 0.5.1'
+  s.add_development_dependency 'rspec', '~> 2.12'
 end

--- a/features/creating_configuration_files.feature
+++ b/features/creating_configuration_files.feature
@@ -1,0 +1,56 @@
+Feature: Creating configuration files
+
+  Run the rake task `config` to create configuration files. These are created
+  by populating configuration values from the environment into template
+  configuration files.
+
+  Templates are identified by a final `.dice` extension in their filename. They
+  can be anywhere in the current working directory or below it. The `.dice`
+  extension is stripped off to create the final configuration filename, which
+  is created beside the template in the same directory.
+
+  Templates are processed as ERB source files. Configuration values from the
+  environment are made available through the `configured` object. If a
+  referenced environment variable is undefined `nil` is returned, allowing you
+  to provide defaults directly in the template.
+
+  Background:
+    Given a file named "Rakefile" with:
+      """
+      require 'dice_bag/tasks'
+      """
+
+  Scenario: Populating a YAML configuration file from an ERB template
+    Given a file named "database.yml.dice" with:
+      """
+      development:
+        database: development
+        username: <%= configured.database_username %>
+        password: <%= configured.database_password %>
+      """
+    When I run `rake DATABASE_USERNAME=alice DATABASE_PASSWORD=xyzzy config`
+    Then the file "database.yml" should contain:
+      """
+      development:
+        database: development
+        username: alice
+        password: xyzzy
+      """
+
+  Scenario: Providing default configuration values
+    Given a file named "database.yml.dice" with:
+      """
+      development:
+        database: development
+        username: <%= configured.database_username || 'root' %>
+        password: <%= configured.database_password %>
+      """
+    When I run `rake config`
+    Then the file "database.yml" should contain:
+      """
+      development:
+        database: development
+        username: root
+        password: 
+      """
+

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,0 +1,2 @@
+require 'aruba/cucumber'
+require 'dice_bag'

--- a/lib/dice_bag/project.rb
+++ b/lib/dice_bag/project.rb
@@ -21,10 +21,16 @@ module DiceBag
 
     #local templates always takes preference over generated templates
     def self.templates_to_generate
+      dice_templates = Dir["**/*.dice"]
+
+      # The following ways of identifying template files will be removed prior
+      # to v1.
       generated_templates = Dir[Project.config_files("**/*.erb")]
       custom_templates = Dir[Project.config_files("**/*.erb.local")]
       dotNetTemplates = Dir[Project.config_files("**/*.config.template")]
-      all_files = generated_templates + custom_templates
+
+      all_files = generated_templates + custom_templates + dice_templates
+
       cleaned_templates = all_files.delete_if {|file| custom_templates.include?(file + '.local')}
       dotNetTemplates = dotNetTemplates.delete_if {|file| file.include?("/bin/")}
       (cleaned_templates + dotNetTemplates).map { |template| File.basename(template) }

--- a/lib/dice_bag/project.rb
+++ b/lib/dice_bag/project.rb
@@ -29,7 +29,12 @@ module DiceBag
       custom_templates = Dir[Project.config_files("**/*.erb.local")]
       dotNetTemplates = Dir[Project.config_files("**/*.config.template")]
 
-      all_files = generated_templates + custom_templates + dice_templates
+      legacy_files = generated_templates + custom_templates + dotNetTemplates
+      legacy_files.each do |file|
+        $stderr.puts "DEPRECATION WARNING: Use '.dice' file extension instead for '#{file}'"
+      end
+
+      all_files = legacy_files + dice_templates
 
       cleaned_templates = all_files.delete_if {|file| custom_templates.include?(file + '.local')}
       dotNetTemplates = dotNetTemplates.delete_if {|file| file.include?("/bin/")}


### PR DESCRIPTION
This change adds infrastructure for the desperately needed scenario-based testing, which will double up as documentation. It also includes a bug fix for `.dice` extension templates, which were being ignored. I found this while creating the scenarios included here, so we're already winning from having these tests!
