### PR TITLE
plugins and rake task can specify the location where the templates will ...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Generated templates should be commited to the git repo
 * New extension .dice for Dicebag's templates
+* Better testing infrastructure
+* Plugins and rake task can specify custom location for templates
 
 # 0.4.1
 

--- a/lib/dice_bag/available_templates.rb
+++ b/lib/dice_bag/available_templates.rb
@@ -1,7 +1,18 @@
+require 'dice_bag/default_template_file'
+
 # This class returns all the templates we can generate in this particular project
 module DiceBag
  
   class AvailableTemplates
+
+
+    # By default the final location for any template will be the config directory.
+    # If any template 'plugin' wants to overwrite the directory where its template will be written
+    # it needs to overwrite this method and return a string with the new location as relative
+    # path inside the project.
+    def templates_location
+      Project.config_dir
+    end
 
     class << self
 
@@ -18,17 +29,18 @@ module DiceBag
         available_templates = []
 
         template_checkers.each do |checker|
+          location = checker.new.templates_location
           checker.new.templates.each do |template|
-            available_templates.push( template)
+            available_templates.push( DefaultTemplateFile.new(template, location) )
           end
         end
         available_templates
       end
 
       def template_filename_for(filename)
-        self.all.each do |template_filename|
-          if template_filename.include? filename
-            return template_filename
+        self.all.each do |template|
+          if template.filename.include? filename
+            return template.file
           end
         end
       end

--- a/lib/dice_bag/available_templates.rb
+++ b/lib/dice_bag/available_templates.rb
@@ -28,9 +28,10 @@ module DiceBag
         #all the classes than inherit from us in the ruby runtime
         available_templates = []
 
-        template_checkers.each do |checker|
-          location = checker.new.templates_location
-          checker.new.templates.each do |template|
+        template_checkers.each do |template_checker|
+          checker = template_checker.new
+          location = checker.templates_location
+          checker.templates.each do |template|
             available_templates.push( DefaultTemplateFile.new(template, location) )
           end
         end

--- a/lib/dice_bag/command.rb
+++ b/lib/dice_bag/command.rb
@@ -31,12 +31,9 @@ module DiceBag
       end
     end
 
-    def generate_template(file)
-      default_template = DefaultTemplateFile.new(file)
+    def generate_template(default_template)
       default_template.assert_existence
-      project_template = TemplateFile.new(File.basename(file))
-
-      default_template.create_file(project_template)
+      default_template.create_file
     end
 
   end

--- a/lib/dice_bag/default_template_file.rb
+++ b/lib/dice_bag/default_template_file.rb
@@ -9,19 +9,23 @@ module DiceBag
   class DefaultTemplateFile
     include DiceBagFile
 
-    def initialize(name)
+    def initialize(name, location=nil)
       #if called from command line with only a name we search in all our templates for the file
       if (File.dirname(name) == '.')
         name = AvailableTemplates.template_filename_for(name)
       end
       @filename = File.basename(name)
       @file = name
+      @template_location = location || Project.config_dir
     end
 
-    def create_file(template_file)
+    def create_file
       contents = read_template(@file)
-      template_file.write(contents)
-      puts "new template file generated in #{template_file.file}.
+      template_file = File.join(Project.root, @template_location, @filename)
+      File.open(template_file, 'w') do |file|
+        file.puts(contents)
+      end
+      puts "new template file generated in #{template_file}.
             execute 'rake config:all' to get the corresponding configuration file."
     end
 

--- a/lib/dice_bag/project.rb
+++ b/lib/dice_bag/project.rb
@@ -10,13 +10,17 @@ module DiceBag
     end
 
     def self.config_files(filename)
-      File.join(self.config_dir, filename)
+      File.join(self.root, self.config_dir, filename)
     end
 
     # dotNet apps do not have the templates in config/ but in the root of the project
     # TODO: detect dotNet instead of detecting rails
     def self.config_dir
-      defined?(Rails) ? File.join(Dir.pwd, 'config') : Dir.pwd
+      defined?(Rails) ? 'config' : "."
+    end
+
+    def self.root
+      Dir.pwd
     end
 
     #local templates always takes preference over generated templates

--- a/lib/dice_bag/tasks/config.rake
+++ b/lib/dice_bag/tasks/config.rake
@@ -22,10 +22,11 @@ namespace :config do
     DiceBag::Command.new.generate_all_templates
   end
 
-  desc "Regenerate a given template"
-  task :generate, :filename do |t, args|
+  desc "Regenerate a given template, params: filename of the template, location for the generated file[optional]"
+  task :generate, :filename, :location do |t, args|
     filename = args[:filename]
+    location = args[:location]
     raise "A filename needs to be provided" if filename.nil?
-    DiceBag::Command.new.generate_template(filename)
+    DiceBag::Command.new.generate_template(DiceBag::DefaultTemplateFile.new(filename,location))
   end
 end

--- a/templates.md
+++ b/templates.md
@@ -16,7 +16,7 @@ be the full path location of one template.
 Example:
 
 ```ruby
-class MyTemplates < Dicebag::AvailableTemplates
+class MyTemplates < DiceBag::AvailableTemplates
   def templates
     all_templates = []
     pwd = File.dirname(__FILE__)

--- a/templates.md
+++ b/templates.md
@@ -16,7 +16,7 @@ be the full path location of one template.
 Example:
 
 ```ruby
-class MyTemplates << Dicebag::AvailableTemplates
+class MyTemplates < Dicebag::AvailableTemplates
   def templates
     all_templates = []
     pwd = File.dirname(__FILE__)

--- a/templates.md
+++ b/templates.md
@@ -36,3 +36,18 @@ you flexibility to introduce logic in your template.
 You can use the 'configured' object to get the information from
 environment variables.
 Check the default templates from Dicebag for examples.
+
+If you want to change the place where Dicebag will write your template
+and the configuration file, you need to create another method which will
+return the path relative to the project root where you want them to be
+generated:
+
+```ruby
+class MyTemplates << Dicebag::AvailableTemplates
+  def templates_location
+    'config/initializers'
+  end
+end
+```
+The templates pointed by the templates method will be written in the
+location pointed by the templates_location method.


### PR DESCRIPTION
...be generated

This allows to generate a template in a given directory, specify in the command line.
Also it allows for plugins to specify where they want to store they templates.
Only one location per plugin to make it simple for now. If a project needs more than one location they can create several plugins.

scenarios do not pass but they do not pass in develop either for me.
