### PR TITLE
Feature/fix custom location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.5.1
+
+* Config files are generated in the same directory where its templates
+  lives. Typically config/ but not necesarily
+
 # 0.5
 
 * Generated templates should be commited to the git repo

--- a/dice_bag.gemspec
+++ b/dice_bag.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.executables = Dir['bin/*'].map{ |f| File.basename(f) }
   s.require_paths = ['lib']
 
+  s.add_dependency 'rake'
   s.add_development_dependency 'aruba', '~> 0.5.1'
   s.add_development_dependency 'rspec', '~> 2.12'
 end

--- a/lib/dice_bag/command.rb
+++ b/lib/dice_bag/command.rb
@@ -19,7 +19,7 @@ module DiceBag
     def write(template_name)
       template_file = TemplateFile.new(template_name)
       template_file.assert_existence
-      config_file = ConfigFile.new(template_name)
+      config_file = ConfigFile.new(template_file)
 
       template_file.create_file(config_file)
     end

--- a/lib/dice_bag/config_file.rb
+++ b/lib/dice_bag/config_file.rb
@@ -6,11 +6,11 @@ module DiceBag
 
   class ConfigFile
     include DiceBagFile
-    def initialize(name)
+    def initialize(template_file)
       # The 'local', 'erb', and 'template' file extension are deprecated and
       # will be removed some time prior to v1.
-      @filename = name.gsub('.local', '').gsub('.erb', '').gsub('.template','').gsub('.dice', '')
-      @file = Project.config_files(@filename)
+      @filename = template_file.filename.gsub('.local', '').gsub('.erb', '').gsub('.template','').gsub('.dice', '')
+      @file = File.join(File.dirname(template_file.file), @filename)
     end
   end
 end

--- a/lib/dice_bag/template_file.rb
+++ b/lib/dice_bag/template_file.rb
@@ -16,7 +16,9 @@ module DiceBag
 
     def initialize(name)
       @filename = File.basename(name)
-      @file = Project.config_files(name)
+      template_file = Dir["**/#{name}"].first
+      abort("template file not found: #{name}") unless template_file
+      @file = File.join(Dir.pwd,template_file)
     end
 
     def create_file(config_file)
@@ -32,7 +34,7 @@ module DiceBag
 
       return unless config_file.should_write?(contents)
       config_file.write(contents)
-      puts "file #{Project.config_dir}/#{config_file.file} created"
+      puts "file #{config_file.file} created"
     end
 
   end

--- a/lib/dice_bag/version.rb
+++ b/lib/dice_bag/version.rb
@@ -1,3 +1,3 @@
 module DiceBag
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 end


### PR DESCRIPTION
Solved a bug.
Now config files are generated in the same directory templates files are in, wherever they are. Instead of Project.config_dir default (which is almost death)

Scenarios for this are coming on a later PR
