### PR TITLE
Bump version to 0.6 and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# On develop branch
+# 0.6.0
 
 * **Breaking change:** Only templates with the '.dice' extension are processed.
 * **Breaking change:** Local override via the '.local' extension has been removed.

--- a/lib/dice_bag/version.rb
+++ b/lib/dice_bag/version.rb
@@ -1,3 +1,3 @@
 module DiceBag
-  VERSION = '0.5.0'
+  VERSION = '0.6.0'
 end


### PR DESCRIPTION
In preparation for release, bump version to 0.6 and update CHANGELOG. Trivial changes, so I'm happy for any passing engineer to review and merge!
