### PR TITLE
Fix Template generation fails if the target directory is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,4 +108,5 @@ rake "config:generate_all" task, you can create a plug-in. Read the
 * [Aaron Weiner](https://github.com/HonoreDB)
 * [Luke Greene](https://github.com/lgreene-mdsol)
 * [Johnny Lo](https://github.com/jlo188)
+* [Connor Ross](https://github.com/cross311)
 

--- a/features/generating_template_files.feature
+++ b/features/generating_template_files.feature
@@ -1,9 +1,5 @@
 Feature: Generating template files
-
-  Background:
-    # That the directory needs to exist is a bug!
-    Given a directory named "config"
-
+  
   Scenario: Generate standard template files
     Given a file named "Rakefile" with:
       """

--- a/features/generating_template_files.feature
+++ b/features/generating_template_files.feature
@@ -38,8 +38,7 @@ Feature: Generating template files
       """
 
   Scenario: Providing templates for a directory other than 'config'
-    Given a directory named "config/initializers"
-    And a file named "Rakefile" with:
+    Given a file named "Rakefile" with:
       """
       require 'dice_bag/tasks'
       require './my_templates/my_template'

--- a/lib/dice_bag/default_template_file.rb
+++ b/lib/dice_bag/default_template_file.rb
@@ -21,7 +21,9 @@ module DiceBag
 
     def create_file
       contents = read_template(@file)
-      template_file = File.join(Project.root, @template_location, @filename)
+      rooted_template_location = File.join(Project.root, @template_location)
+      Dir.mkdir(rooted_template_location) unless Dir.exist?(rooted_template_location)
+      template_file = File.join(rooted_template_location, @filename)
       File.open(template_file, 'w') do |file|
         file.puts(contents)
       end

--- a/lib/dice_bag/default_template_file.rb
+++ b/lib/dice_bag/default_template_file.rb
@@ -1,6 +1,7 @@
 require 'dice_bag/dice_bag_file'
 require 'dice_bag/project'
 
+require 'fileutils'
 require 'tempfile'
 
 #This file encapsulate the template files Dicebag brings with itself
@@ -22,7 +23,7 @@ module DiceBag
     def create_file
       contents = read_template(@file)
       rooted_template_location = File.join(Project.root, @template_location)
-      Dir.mkdir(rooted_template_location) unless Dir.exist?(rooted_template_location)
+      FileUtils.mkdir_p(rooted_template_location)
       template_file = File.join(rooted_template_location, @filename)
       File.open(template_file, 'w') do |file|
         file.puts(contents)


### PR DESCRIPTION
DefaultTemplateFile now checks for folder location before writing template. BUG #50.  Decided to do it in DefaultTemplateFile due to AvailableTemplates.templates_location could be over written with another path, so technically each template file generated could have a different folder location.
### Questions:

Should I bump the version?
### Notes:

Just trying to brush up on my ruby (it has been a long time) so all criticism is welcome.  Thought a good way to brush up would be to help fix some bugs in MDSOL open source projects.
### Tests:

22 scenarios (22 passed)
83 steps (83 passed)
0m7.150s

Please review @asmith-mdsol 
