### PR TITLE
Don't overwrite config files if user responds 'No' instead of just 'N'.

### DIFF
--- a/features/replacing_existing_configuration_files.feature
+++ b/features/replacing_existing_configuration_files.feature
@@ -45,6 +45,22 @@ Feature: Replacing existing configuration files
       config: old value
       """
 
+  Scenario: Deny configuration file replacement with 'No' instead of 'n'
+    Given a file named "config.yml.dice" with:
+      """
+      config: <%= configured.value %>
+      """
+    And a file named "config.yml" with:
+      """
+      config: old value
+      """
+    When I run `rake VALUE='new value' config` interactively
+    And I type "No"
+    Then the file "config.yml" should contain:
+      """
+      config: old value
+      """
+
   Scenario: Replace all configuration files
     Given a file named "config_1.yml.dice" with:
       """

--- a/features/replacing_existing_configuration_files.feature
+++ b/features/replacing_existing_configuration_files.feature
@@ -45,7 +45,7 @@ Feature: Replacing existing configuration files
       config: old value
       """
 
-  Scenario: Deny configuration file replacement with 'No' instead of 'n'
+  Scenario: Deny configuration file replacement with 'No' in addition to 'n'
     Given a file named "config.yml.dice" with:
       """
       config: <%= configured.value %>

--- a/lib/dice_bag/dice_bag_file.rb
+++ b/lib/dice_bag/dice_bag_file.rb
@@ -26,7 +26,8 @@ module DiceBag
       while true
         puts "Overwrite #{file} ?    Recommended: Yes. "
         puts " [Y]es, [n]o, [a]ll files, [q]uit, [d]show diff"
-        answer = $stdin.gets.tap{|text| text.strip!.downcase! if text}
+        answer = $stdin.gets
+        answer &&= answer.chars.first.downcase
         case answer
         when 'y'
           return true


### PR DESCRIPTION
I was messing with my config files in MCC Admin and accidentally overwrote my mauth_key without realizing it, because I responded "no" to the prompt instead of just "n".  This change addresses this by only looking at the first letter of the user's response.

23 scenarios (23 passed)
87 steps (87 passed)
0m17.656s
