### PR TITLE
Feature/update database yml template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.1
+* Updates the database.yml.dice file to not provide settings for test and development when 
+ building in production.
+
 # 1.1.0
 
 * Removed the template for Newrelic.

--- a/lib/dice_bag/templates/database.yml.dice
+++ b/lib/dice_bag/templates/database.yml.dice
@@ -1,12 +1,15 @@
 <%= warning.as_yaml_comment %>
 
-<% [:development, :test, :production].each do |env| %>
+<% environments = Rails.env.production? ? [:production] : [:development, :test] %>
+
+<% environments.each do |env| %>
 <%= env %>:
   adapter: <%= configured[env].database_driver || 'mysql2' %>
-  database: <%= configured[env].database_name || "PROJECT_NAME_#{env}" %><%= ('<'+'%=ENV["TEST_ENV_NUMBER"] %'+'>') if (env == :test) %>
-  username: <%= configured[env].database_username || 'root' %>
-  password: <%= configured[env].database_password %>
-  host: <%= configured[env].database_host || 'localhost' %>
+  database: <%= configured[env].database_name! || "PROJECT_NAME_#{env}" %><%= ('<'+'%=ENV["TEST_ENV_NUMBER"] %'+'>') if (env == :test) %>
+  username: <%= configured[env].database_username! || 'root' %>
+  password: <%= configured[env].database_password! %>
+  host: <%= configured[env].database_host! || 'localhost' %>
+  port: <%= configured[env].database_port || 3306 %>
   pool: <%= configured[env].database_pool || 5 %>
   timeout: <%= configured[env].database_timeout || 5000 %>
   encoding:  <%= configured[env].database_encoding || 'utf8' %>

--- a/lib/dice_bag/version.rb
+++ b/lib/dice_bag/version.rb
@@ -1,3 +1,3 @@
 module DiceBag
-  VERSION = '1.1.0'
+  VERSION = '1.1.1'
 end


### PR DESCRIPTION
Puts in bangs to require that the database_name, password, host, and username are provided when building in production. Also does not build the test/development settings out when running rake config in the production environment. This prevents db:test:prepare or any other default take task that runs on test or development environment to perform actions on the production database.
