### PR TITLE
Refactoring styles: follow the standard Ruby style guide

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 gemspec

--- a/dice_bag.gemspec
+++ b/dice_bag.gemspec
@@ -1,24 +1,24 @@
-require File.expand_path('../lib/dice_bag/version', __FILE__)
+require File.expand_path("../lib/dice_bag/version", __FILE__)
 
 Gem::Specification.new do |s|
-  s.name = 'dice_bag'
+  s.name = "dice_bag"
   s.version = DiceBag::VERSION
   s.platform = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 1.8.7'
+  s.required_ruby_version = ">= 1.8.7"
 
-  s.authors = ['Andrew Smith', 'Jordi Carres']
-  s.email = ['asmith@mdsol.com', 'jcarres@mdsol.com']
-  s.summary = 'Dice Bag is a library of rake tasks for configuring web apps in the style of The Twelve-Factor App. It also provides continuous integration tasks that rely on the configuration tasks.'
+  s.authors = ["Andrew Smith", "Jordi Carres"]
+  s.email = ["asmith@mdsol.com", "jcarres@mdsol.com"]
+  s.summary = "Dice Bag is a library of rake tasks for configuring web apps in the style of The Twelve-Factor App. It also provides continuous integration tasks that rely on the configuration tasks."
   s.homepage = "https://github.com/mdsol/dice_bag"
 
-  s.files = Dir['lib/**/*']
-  s.test_files = Dir['spec/**/*']
-  s.require_paths = ['lib']
+  s.files = Dir["lib/**/*"]
+  s.test_files = Dir["spec/**/*"]
+  s.require_paths = ["lib"]
 
-  s.add_dependency 'rake'
-  s.add_dependency 'thor', '~> 0.0'
-  s.add_dependency 'diff-lcs', '~> 1.0'
-  s.add_development_dependency 'aruba', '~> 0.5.1'
-  s.add_development_dependency 'rspec', '~> 3.0'
-  s.add_development_dependency 'bundler'
+  s.add_dependency "rake"
+  s.add_dependency "thor", "~> 0.0"
+  s.add_dependency "diff-lcs", "~> 1.0"
+  s.add_development_dependency "aruba", "~> 0.5.1"
+  s.add_development_dependency "rspec", "~> 3.0"
+  s.add_development_dependency "bundler"
 end

--- a/features/step_definitions/gemfile.rb
+++ b/features/step_definitions/gemfile.rb
@@ -1,8 +1,8 @@
 
 Given /a Gemfile with dice_bag as a dependency/ do
-  write_file('Gemfile', <<-EOF)
+  write_file("Gemfile", <<-EOF)
     source 'https://rubygems.org'
 
-    gem 'dice_bag', path: '#{File.join(File.dirname(__FILE__),'../..')}'
+    gem 'dice_bag', path: '#{File.join(File.dirname(__FILE__), '../..')}'
   EOF
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,3 +1,2 @@
-require 'aruba/cucumber'
-require 'dice_bag'
-
+require "aruba/cucumber"
+require "dice_bag"

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -2,7 +2,7 @@ Before do
   write_file("Rakefile", "require 'dice_bag/tasks'")
 end
 
-Around '@clean-bundler-environment' do |_, block|
+Around "@clean-bundler-environment" do |_, block|
   if defined?(Bundler)
     Bundler.with_clean_env do
       block.call

--- a/lib/dice_bag.rb
+++ b/lib/dice_bag.rb
@@ -1,4 +1,4 @@
-require_relative 'dice_bag/available_templates'
+require_relative "dice_bag/available_templates"
 module DiceBag
-  require 'dice_bag/railtie' if defined?(Rails)
+  require "dice_bag/railtie" if defined?(Rails)
 end

--- a/lib/dice_bag/available_templates.rb
+++ b/lib/dice_bag/available_templates.rb
@@ -1,21 +1,18 @@
-require 'rubygems'
-require 'dice_bag/default_template_file'
+require "rubygems"
+require "dice_bag/default_template_file"
 
 # This class returns all the templates we can generate in this particular project
 module DiceBag
-
   class AvailableTemplates
-
     # By default the final location for any template will be the config directory.
     # If any template 'plugin' wants to overwrite the directory where its template will be written
     # it needs to overwrite this method and return a string with the new location as relative
     # path inside the project.
     def templates_location
-      'config'
+      "config"
     end
 
     class << self
-
       def gem_specs
         @gem_specs ||= begin
           Gem::Specification.sort.each_with_object({}) do |spec, hsh|
@@ -29,6 +26,7 @@ module DiceBag
         gem_specs.each do |name, location|
           return true if checker_file.start_with?(location) && gem_names.include?(name)
         end
+
         false
       end
 
@@ -40,36 +38,30 @@ module DiceBag
         template_checkers << base
       end
 
-      def all(gem_names=[])
-        #all the classes than inherit from us in the ruby runtime
+      def all(gem_names = [])
+        # all the classes than inherit from us in the ruby runtime
         available_templates = []
 
         template_checkers.each do |template_checker|
           checker = template_checker.new
           next if !gem_names.empty? && !checker_within_given_gems?(checker, gem_names)
+
           location = checker.templates_location
           checker.templates.each do |template, save_as|
-            available_templates.push( DefaultTemplateFile.new(template, location, save_as) )
+            available_templates.push(DefaultTemplateFile.new(template, location, save_as))
           end
         end
         available_templates
       end
 
       def template_filename_for(filename)
-        self.all.each do |template|
-          if template.filename.include? filename
-            return template.file
-          end
-        end
+        all.find { |template| template.filename.include?(filename) }
       end
     end
-
   end
-
 end
-
 
 # we require our own templates checker here, for other gems we just need
 # them to inherit from DiceBag::AvailableTemplates and require the file
 # If Ruby loads the file we can find the class in the object space and call it
-require_relative 'templates/gems_checker'
+require_relative "templates/gems_checker"

--- a/lib/dice_bag/command.rb
+++ b/lib/dice_bag/command.rb
@@ -1,14 +1,14 @@
-require 'dice_bag/available_templates'
-require 'dice_bag/project'
-require 'dice_bag/config_file'
-require 'dice_bag/template_file'
-require 'dice_bag/default_template_file'
-require 'thor'
+require "dice_bag/available_templates"
+require "dice_bag/project"
+require "dice_bag/config_file"
+require "dice_bag/template_file"
+require "dice_bag/default_template_file"
+require "thor"
 
 module DiceBag
-  #This class seems a candidate to be converted to Thor, the problem is that we need to run
-  #in the same process than the rake task so all the gems are loaded before dice_bag
-  #is called and dice_bag can find what software is used in this project
+  # This class seems a candidate to be converted to Thor, the problem is that we need to run
+  # in the same process than the rake task so all the gems are loaded before dice_bag
+  # is called and dice_bag can find what software is used in this project
   class Command
     include Thor::Base
     include Thor::Actions
@@ -31,21 +31,20 @@ module DiceBag
       template_file.create_file(config_file, params)
     end
 
-    def generate_all_templates(force=false)
+    def generate_all_templates(force = false)
       AvailableTemplates.all.each do |template|
         generate_template(template, force)
       end
     end
 
-    def generate_template(default_template, force=false)
+    def generate_template(default_template, force = false)
       copy_file default_template.file, default_template.destination, force: force
     end
 
-    def generate_gems_templates(gem_names, force=false)
+    def generate_gems_templates(gem_names, force = false)
       AvailableTemplates.all(gem_names).each do |template|
         generate_template(template, force)
       end
     end
-
   end
 end

--- a/lib/dice_bag/config_file.rb
+++ b/lib/dice_bag/config_file.rb
@@ -1,15 +1,15 @@
-require 'dice_bag/dice_bag_file.rb'
-require 'dice_bag/project'
+require "dice_bag/dice_bag_file.rb"
+require "dice_bag/project"
 
-#this class encapsulate a configuration file of the project
+# this class encapsulate a configuration file of the project
 module DiceBag
-
   class ConfigFile
     include DiceBagFile
+
     def initialize(name)
       # The 'local', 'erb', and 'template' file extension are deprecated and
       # will be removed some time prior to v1.
-      @filename = name.gsub('.local', '').gsub('.erb', '').gsub('.template','').gsub('.dice', '')
+      @filename = name.gsub(".local", "").gsub(".erb", "").gsub(".template", "").gsub(".dice", "")
       @file = Project.config_files(@filename)
     end
   end

--- a/lib/dice_bag/configuration.rb
+++ b/lib/dice_bag/configuration.rb
@@ -1,12 +1,10 @@
 module DiceBag
-
   # This class abstracts access to configuration values, to be used within ERB
   # templates. Currently, the values are read from the environment, as per the
   # Twelve-Factor App principles.
   class Configuration
-
     def initialize
-      @prefixed = Hash.new
+      @prefixed = {}
     end
 
     # Returns a Configuration::PrefixedWithFallback using the given +prefix+.
@@ -16,7 +14,7 @@ module DiceBag
     end
 
     def method_missing(name)
-      if name.to_s.end_with?('!')
+      if name.to_s.end_with?("!")
         ensured_in_production(name)
       else
         ENV[name.to_s.upcase]
@@ -26,7 +24,7 @@ module DiceBag
     private
 
     def ensured_in_production(name)
-      variable_name = name.to_s.chomp('!').upcase
+      variable_name = name.to_s.chomp("!").upcase
       value = ENV[variable_name]
       if in_production? && value.nil?
         raise "Environment variable #{variable_name} required in production but it was not provided"
@@ -36,8 +34,8 @@ module DiceBag
 
     def in_production?
       (defined?(Rails) && Rails.env.production?) ||
-      (defined?(Sinatra) && Sinatra::Application.production?) ||
-      ENV['RACK_ENV'] == 'production'
+        (defined?(Sinatra) && Sinatra::Application.production?) ||
+        ENV["RACK_ENV"] == "production"
     end
 
     # This class acts like +Configuration+ but with a prefix applied to the
@@ -53,9 +51,8 @@ module DiceBag
       end
 
       def method_missing(name)
-        ENV["#{ @prefix }_#{ name.to_s.upcase }"] || @fallback.send(name)
+        ENV["#{@prefix}_#{name.to_s.upcase}"] || @fallback.send(name)
       end
     end
   end
-
 end

--- a/lib/dice_bag/default_template_file.rb
+++ b/lib/dice_bag/default_template_file.rb
@@ -1,18 +1,17 @@
-require 'dice_bag/dice_bag_file'
-require 'dice_bag/project'
+require "dice_bag/dice_bag_file"
+require "dice_bag/project"
 
-require 'fileutils'
-require 'tempfile'
+require "fileutils"
+require "tempfile"
 
-#This file encapsulate the template files Dicebag brings with itself
+# This file encapsulate the template files Dicebag brings with itself
 module DiceBag
-
   class DefaultTemplateFile
     include DiceBagFile
 
-    def initialize(name, location=nil, save_as=nil)
-      #if called from command line with only a name we search in all our templates for the file
-      if (File.dirname(name) == '.')
+    def initialize(name, location = nil, save_as = nil)
+      # if called from command line with only a name we search in all our templates for the file
+      if File.dirname(name) == "."
         name = AvailableTemplates.template_filename_for(name)
       end
       @filename = File.basename(save_as || name)
@@ -20,6 +19,5 @@ module DiceBag
       @template_location = location
       @destination = File.join(Project.root, @template_location, @filename)
     end
-
   end
 end

--- a/lib/dice_bag/dice_bag_file.rb
+++ b/lib/dice_bag/dice_bag_file.rb
@@ -1,4 +1,4 @@
-require 'dice_bag/version'
+require "dice_bag/version"
 
 # This module contains common methods for all the type of files Dicebag knows about:
 # configuration files, templates files in the project an templates files shipped with dicebag
@@ -14,7 +14,7 @@ module DiceBag
     end
 
     def write(contents)
-      File.open(@file, 'w') do |file|
+      File.open(@file, "w") do |file|
         file.puts(contents)
       end
     end
@@ -29,15 +29,15 @@ module DiceBag
         answer = $stdin.gets
         answer &&= answer.chars.first.downcase
         case answer
-        when 'y'
+        when "y"
           return true
-        when 'n'
+        when "n"
           return false
-        when 'a'
+        when "a"
           return @@overwrite_all = true
-        when 'q'
+        when "q"
           exit
-        when 'd'
+        when "d"
           puts diff(file, new_contents)
         else
           return true
@@ -46,8 +46,9 @@ module DiceBag
     end
 
     private
+
     def diff(destination, content)
-      diff_cmd = ENV['RAILS_DIFF'] || 'diff -u'
+      diff_cmd = ENV["RAILS_DIFF"] || "diff -u"
       Tempfile.open(File.basename(destination), File.dirname(destination)) do |temp|
         temp.write content
         temp.rewind

--- a/lib/dice_bag/private_key.rb
+++ b/lib/dice_bag/private_key.rb
@@ -1,40 +1,39 @@
 module DiceBag
   class PrivateKey
-
     attr_accessor :private_key
-    @@header = "-----BEGIN RSA PRIVATE KEY-----"
-    @@footer = "-----END RSA PRIVATE KEY-----"
 
     def initialize(key)
       @private_key = key
     end
 
-    def is_valid_private_key?
-      require 'openssl'
+    def valid_private_key?
+      require "openssl"
+
       begin
         OpenSSL::PKey::RSA.new @private_key
-        return true  
+        true
       rescue => e
-        p e.message
-        p e.backtrace
-        return false
+        puts "#{e.message}\n#{e.backtrace}"
+        false
       end
-    end 
+    end
 
     def to_rsa_format!
       strip_down_key
       body = @private_key.split(/\s+/)
       body = body.first.scan(/.{1,64}/) if body.length == 1
-    	@private_key = [@@header, body, @@footer].flatten.join("\n")
+      @private_key = [HEADER, body, FOOTER].flatten.join("\n")
     end
 
     private
 
+    HEADER = "-----BEGIN RSA PRIVATE KEY-----".freeze
+    FOOTER = "-----END RSA PRIVATE KEY-----".freeze
+
     def strip_down_key
-      @private_key.gsub!(@@header,"")
-      @private_key.gsub!(@@footer,"")
+      @private_key.gsub!(HEADER, "")
+      @private_key.gsub!(FOOTER, "")
       @private_key.strip!
     end
-
   end
 end

--- a/lib/dice_bag/project.rb
+++ b/lib/dice_bag/project.rb
@@ -1,16 +1,15 @@
-#This class encapsulate data about the project dice_bag got in
+# This class encapsulate data about the project dice_bag got in
 module DiceBag
-
   class Project
+    DEFAULT_NAME = "project"
 
-    DEFAULT_NAME = 'project'
     def self.name
-      #TODO: how to do find the name of the project in no-rails environments?
+      # TODO: how to do find the name of the project in no-rails environments?
       defined?(Rails) ? Rails.application.class.parent_name.downcase : DEFAULT_NAME
     end
 
     def self.config_files(filename)
-      File.join(self.root, filename)
+      File.join(root, filename)
     end
 
     def self.root
@@ -18,8 +17,8 @@ module DiceBag
     end
 
     def self.templates_to_generate
-      FileList.new('**/*.dice') do |fl|
-        fl.exclude(File.join(Bundler.settings[:path],'/**/*')) if defined?(Bundler) && Bundler.settings[:path]
+      FileList.new("**/*.dice") do |fl|
+        fl.exclude(File.join(Bundler.settings[:path], "/**/*")) if defined?(Bundler) && Bundler.settings[:path]
       end
     end
   end

--- a/lib/dice_bag/railtie.rb
+++ b/lib/dice_bag/railtie.rb
@@ -1,7 +1,7 @@
 module DiceBag
   class Railtie < Rails::Railtie
     rake_tasks do
-      require 'dice_bag/tasks'
+      require "dice_bag/tasks"
     end
   end
 end

--- a/lib/dice_bag/tasks.rb
+++ b/lib/dice_bag/tasks.rb
@@ -1,1 +1,1 @@
-load 'dice_bag/tasks/config.rake'
+load "dice_bag/tasks/config.rake"

--- a/lib/dice_bag/template_file.rb
+++ b/lib/dice_bag/template_file.rb
@@ -1,17 +1,14 @@
-require 'dice_bag/dice_bag_file.rb'
-require 'dice_bag/template_helpers'
-require 'dice_bag/configuration'
-require 'dice_bag/warning'
+require "dice_bag/dice_bag_file.rb"
+require "dice_bag/template_helpers"
+require "dice_bag/configuration"
+require "dice_bag/warning"
 
-#this class encapsulates the template files we will generate in the project 
-#using this gem
+# This class encapsulates the template files we will generate in the project using this gem.
 module DiceBag
-
   class TemplateFile
     include DiceBagFile
 
-    # Methods from this module need to be called directly from within the ERB
-    # templates.
+    # Methods from this module need to be called directly from within the ERB templates.
     include DiceBag::TemplateHelpers
 
     def initialize(name)
@@ -25,15 +22,15 @@ module DiceBag
       # like mauth_key where we want to control newlines carefully.
       template = ERB.new(File.read(@file), nil, "<>")
 
-      #templates expect a configured object
+      # templates expect a configured object
       configured = Configuration.new
       warning = Warning.new(@filename)
       contents = template.result(binding)
 
       return unless params[:deploy] || config_file.should_write?(contents)
+
       config_file.write(contents)
       puts "File '#{config_file.file}' created"
     end
-
   end
 end

--- a/lib/dice_bag/template_helpers.rb
+++ b/lib/dice_bag/template_helpers.rb
@@ -1,21 +1,21 @@
-require 'dice_bag/private_key'
+require "dice_bag/private_key"
 
 module DiceBag
   module TemplateHelpers
     def generate_private_key
-      require 'openssl'
+      require "openssl"
       OpenSSL::PKey::RSA.generate(2048)
     end
 
     def ensure_is_private_key(key)
-    	pkey = PrivateKey.new key.dup
+      pkey = PrivateKey.new key.dup
       pkey.to_rsa_format!
-      if pkey.is_valid_private_key?
+
+      if pkey.valid_private_key?
         pkey.private_key
       else
         raise "The private key provided is invalid"
       end
     end
-
   end
 end

--- a/lib/dice_bag/templates/gems_checker.rb
+++ b/lib/dice_bag/templates/gems_checker.rb
@@ -2,31 +2,30 @@
 # generated for this project.
 # this file lives in the same directory than all the templates it
 # provides logic for.
-require 'dice_bag'
+require "dice_bag"
 
 module DiceBag
   class CommonTemplatesBag < AvailableTemplates
-
     def templates
       @needed_templates = []
       configured = Configuration.new
 
       if defined?(Dalli)
-        add_template('dalli.yml.dice')
+        add_template("dalli.yml.dice")
       end
 
       if defined?(Mysql2)
-        add_template('databases/mysql.yml.dice', save_as: 'database.yml.dice')
+        add_template("databases/mysql.yml.dice", save_as: "database.yml.dice")
       elsif defined?(PG)
-        add_template('databases/postgres.yml.dice', save_as: 'database.yml.dice')
+        add_template("databases/postgres.yml.dice", save_as: "database.yml.dice")
       end
 
       if defined?(AWS)
-        add_template('aws.yml.dice')
+        add_template("aws.yml.dice")
       end
 
       if configured.google_analytics_id
-        add_template('google_analytics.yml.dice')
+        add_template("google_analytics.yml.dice")
       end
 
       @needed_templates
@@ -36,7 +35,5 @@ module DiceBag
       pwd = File.dirname(__FILE__)
       @needed_templates.push([File.join(pwd, file), save_as])
     end
-
   end
-
 end

--- a/lib/dice_bag/version.rb
+++ b/lib/dice_bag/version.rb
@@ -1,3 +1,3 @@
 module DiceBag
-  VERSION = '1.3.0'
+  VERSION = "1.3.0"
 end

--- a/lib/dice_bag/warning.rb
+++ b/lib/dice_bag/warning.rb
@@ -1,6 +1,5 @@
 module DiceBag
   class Warning
-
     def initialize(template_filename)
       @template_filename = template_filename
     end
@@ -12,7 +11,7 @@ module DiceBag
     alias :as_yaml_comment :as_ruby_comment
 
     def as_xml_comment
-      ['<!--', lines, '-->'].flatten.join("\n")
+      ["<!--", lines, "-->"].flatten.join("\n")
     end
 
     protected

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -1,13 +1,12 @@
-require 'spec_helper'
-require 'dice_bag/project'
+require "spec_helper"
+require "dice_bag/project"
 
 describe DiceBag::Project do
   let(:project) { DiceBag::Project }
 
-  describe "#name" do 
+  describe "#name" do
     it "should give me a default name for non Rails apps" do
       expect(project.name).to eq(DiceBag::Project::DEFAULT_NAME)
     end
   end
-
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,24 +1,23 @@
-require 'spec_helper'
-require 'dice_bag/configuration'
-module DiceBag
+require "spec_helper"
+require "dice_bag/configuration"
 
-  shared_examples_for 'configuration in production' do
-    it 'returns values ending in ! available in the environment' do
+module DiceBag
+  shared_examples_for "configuration in production" do
+    it "returns values ending in ! available in the environment" do
       expect(Configuration.new.test_var!).to eq(value)
     end
-    it 'returns values not ending in ! not available in the environment' do
+    it "returns values not ending in ! not available in the environment" do
       expect(Configuration.new.idontexist).to eq(nil)
     end
-    it 'raises an exception when the value ends in ! and is not available in the environment' do
-      expect{Configuration.new.idontexist!}.to raise_exception(StandardError)
+    it "raises an exception when the value ends in ! and is not available in the environment" do
+      expect { Configuration.new.idontexist! }.to raise_exception(StandardError)
     end
   end
 
-
   RSpec.describe Configuration do
-    let(:value) { '42' }
+    let(:value) { "42" }
     before(:each) do
-      ENV['TEST_VAR'] = value
+      ENV["TEST_VAR"] = value
     end
 
     it "returns values" do
@@ -28,34 +27,33 @@ module DiceBag
       expect(Configuration.new.test_var!).to eq(value)
     end
 
-    context 'Running in Rails production environment' do
+    context "Running in Rails production environment" do
       before(:each) do
-        rails = class_double('Rails')
+        rails = class_double("Rails")
         allow(rails).to receive_message_chain("env.production?") { true }
         stub_const("Rails", rails)
       end
-      it_behaves_like 'configuration in production'
+      it_behaves_like "configuration in production"
     end
 
-    context 'Running in Sinatra production environment' do
+    context "Running in Sinatra production environment" do
       before(:each) do
-        sinatra = class_double('Sinatra')
+        sinatra = class_double("Sinatra")
         allow(sinatra).to receive(:production?).and_return(true)
         stub_const("Sinatra::Application", sinatra)
       end
-      it_behaves_like 'configuration in production'
+      it_behaves_like "configuration in production"
     end
 
-    context 'Running in a rack app production environment' do
+    context "Running in a rack app production environment" do
       # Not the most elegant but given how much we use ENV in these tests, does seem good enough
       before(:each) do
-        ENV['RACK_ENV'] = 'production'
+        ENV["RACK_ENV"] = "production"
       end
       after(:each) do
-        ENV['RACK_ENV'] = nil
+        ENV["RACK_ENV"] = nil
       end
-      it_behaves_like 'configuration in production'
+      it_behaves_like "configuration in production"
     end
-
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,11 @@
 # Require this file using `require "spec_helper"` to ensure that it is only
 # loaded once.
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
-require 'dice_bag'
-require 'rspec'
+require "dice_bag"
+require "rspec"
 
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
-  config.order = 'random'
+  config.order = "random"
 end


### PR DESCRIPTION
When working on this repo, I noticed there are places that are not following the [Ruby style guide](https://github.com/rubocop-hq/ruby-style-guide). This PR is focused to make the quick wins to fix the style problems around spacing, empty line, comments, etc.

## Motivation

Having a clean codebase would encourage developers to contribute more, focus on the problems they want to solve and not distract by the low-level styles.

I feel I'm more motivated to walk around the codebase after these cleanup 🙂.

## Approach

I used the default setting of Rubocop that mostly follows the Ruby style guide.
Each commit is fixing one style problem with the auto-correction, plus manual change if needed.
Plan to squash the commits all once review is completed, for now, expanding them for easier review and discussions.

## Single quote vs double quote ❓ 

This is the one style I haven't addressed. The two styles are mingled in the project, seemingly single quote is taking more territory, but let me know which one we'd like to follow. I'll update them all in once.

@mdsol/team-10 Please 🙏 