### PR TITLE
Fix adapter name in the database.yml.dice template for PostgreSQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.3.1
+* Fix adapter name in the database.yml.dice template for PostgreSQL.
+
 # 1.3.0
 * Detect pg gem and generate database.yml.dice for PostgreSQL.
 

--- a/features/generating_template_files.feature
+++ b/features/generating_template_files.feature
@@ -19,7 +19,7 @@ Feature: Generating template files
       module PG; end
       """
     When I run `rake config:generate_all`
-    Then the file "config/database.yml.dice" should match /adapter.*postgres/
+    Then the file "config/database.yml.dice" should match /adapter.*postgresql/
 
   Scenario: Creating your own template provider
     Given a file named "Rakefile" with:

--- a/lib/dice_bag/templates/databases/postgres.yml.dice
+++ b/lib/dice_bag/templates/databases/postgres.yml.dice
@@ -4,7 +4,7 @@
 
 <% environments.each do |env| %>
 <%= env %>:
-  adapter: <%= configured[env].database_driver || 'postgres' %>
+  adapter: <%= configured[env].database_driver || 'postgresql' %>
   database: <%= configured[env].database_name! || "PROJECT_NAME_#{env}" %><%= ('<'+'%=ENV["TEST_ENV_NUMBER"] %'+'>') if (env == :test) %>
   username: <%= configured[env].database_username! || 'postgres' %>
   password: <%= configured[env].database_password! %>

--- a/lib/dice_bag/version.rb
+++ b/lib/dice_bag/version.rb
@@ -1,3 +1,3 @@
 module DiceBag
-  VERSION = "1.3.0"
+  VERSION = "1.3.1"
 end


### PR DESCRIPTION
Otherwise

> LoadError: Could not load the 'postgres' Active Record adapter. Ensure that the adapter is spelled correctly in config/database.yml and that you've added the necessary adapter gem to your Gemfile.

@mdsol/team-10 