### PR TITLE
Specify license on gemspec

### DIFF
--- a/dice_bag.gemspec
+++ b/dice_bag.gemspec
@@ -6,6 +6,8 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.required_ruby_version = ">= 1.8.7"
 
+  s.license = 'MIT'
+
   s.authors = ["Andrew Smith", "Jordi Carres"]
   s.email = ["asmith@mdsol.com", "jcarres@mdsol.com"]
   s.summary = "Dice Bag is a library of rake tasks for configuring web apps in the style of The Twelve-Factor App. It also provides continuous integration tasks that rely on the configuration tasks."


### PR DESCRIPTION
GitHub detects that the license for this repo, [located in the root of the project as `LICENSE`](https://github.com/mdsol/dice_bag/blob/develop/LICENSE) is an MIT license, however the gemspec does not actually specify it as such.

The company now has an initiative to use [FOSSA](https://fossa.io/), a license detection software to check whether our projects are compliant with open source software licenses. Because this gemspec doesn't explicitly specify which license is being used that is causing it to be flagged by FOSSA as having no license:

<img width="769" alt="screen shot 2018-10-17 at 2 21 23 pm" src="https://user-images.githubusercontent.com/951821/47107937-9ffce800-d218-11e8-8472-471ca27e5b37.png">

