### PR TITLE
Updates development dependency. Adds Ruby 2.6 to list of Ruby versions tested.

### DIFF
--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,1 +1,0 @@
-dice_bag

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: ruby
+cache: bundler
 rvm:
-- 2.3.7
-- 2.4.4
-- 2.5.1
-before_install:
-- gem update bundler
-script: bundle exec rspec && bundle exec cucumber
+- 2.3.8
+- 2.4.5
+- 2.5.3
+- 2.6.0
+script:
+  - bundle exec rspec
+  - bundle exec cucumber
 deploy:
   provider: rubygems
   api_key:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.3.2
+* Gem specifies MIT license
+
 # 1.3.1
 * Fix adapter name in the database.yml.dice template for PostgreSQL.
 

--- a/dice_bag.gemspec
+++ b/dice_bag.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.name = "dice_bag"
   s.version = DiceBag::VERSION
   s.platform = Gem::Platform::RUBY
-  s.required_ruby_version = ">= 1.8.7"
+  s.required_ruby_version = ">= 2.3.0"
 
   s.license = 'MIT'
 
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rake"
   s.add_dependency "thor", "~> 0.0"
   s.add_dependency "diff-lcs", "~> 1.0"
-  s.add_development_dependency "aruba", "~> 0.5.1"
+  s.add_development_dependency "aruba", "~> 0.6.0"
   s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "bundler"
 end

--- a/features/ignore_configuration_files_in_bundled_gems.feature
+++ b/features/ignore_configuration_files_in_bundled_gems.feature
@@ -8,7 +8,7 @@ Feature: Ignore configuration files in bundled gems
 
   @clean-bundler-environment
   Scenario: Ignoring files in the bundle path
-    Given The default aruba timeout is 15 seconds
+    Given the default aruba timeout is 15 seconds
     And a Gemfile with dice_bag as a dependency
     And an empty file named "excluded-bundled-gems/subdir/config.yml.dice"
     When I run `bundle install --path=excluded-bundled-gems`
@@ -17,7 +17,7 @@ Feature: Ignore configuration files in bundled gems
 
   @clean-bundler-environment
   Scenario: Not ignoring files outside the bundle path
-    Given The default aruba timeout is 15 seconds
+    Given the default aruba timeout is 15 seconds
     And a Gemfile with dice_bag as a dependency
     And an empty file named "subdir/config.yml.dice"
     When I run `bundle install --path=excluded-bundled-gems`

--- a/lib/dice_bag/version.rb
+++ b/lib/dice_bag/version.rb
@@ -1,3 +1,3 @@
 module DiceBag
-  VERSION = "1.3.1"
+  VERSION = "1.3.2"
 end


### PR DESCRIPTION
#91  brought the license to the gemspec file but we never released that.
After this is merged we can release 1.3.2 
As I was here, I've done a couple of updates.
@mdsol/team-10  @abhitrivedi 