### PR TITLE
Remove unnecessary miss-leading comment.

### DIFF
--- a/lib/dice_bag/tasks/config.rake
+++ b/lib/dice_bag/tasks/config.rake
@@ -9,7 +9,6 @@ desc "Populate all templates using values from the environment to create configu
 task config: ["config:all"]
 
 namespace :config do
-  # Deprecated, present only for backward compatibility.
   task :all do
     DiceBag::Command.new.write_all
   end


### PR DESCRIPTION
Deprecation comment was added in refactor 65d160c6e

`rake config` is the officially documented command, which is an alias for `rake config:all` 

Does not hurt to keep both. No plan to remove at this point.

Fixes https://github.com/mdsol/dice_bag/issues/89

cc: @cabbott @JordiPolo @jfeltesse-mdsol @johngluckmdsol
