### PR TITLE
Update rubygems API key in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
 deploy:
   provider: rubygems
   api_key:
-    secure: OOaw+kt318CvvkzqnNO6FpbNUdlS4vDK+0LNLD4fgncZ1Lx+cIx3FmBnB3C8MYDWLGciw9qwZ/JnYIn7v9a5IWuC3Yeag+l7KgC5KTxn2j/11NfAPymow+r9RPgsAlkDiUkm7uSw7Se87JsA2l4PZIr5bDhjTKiYXwHL/gaHg2U=
+    secure: Ud+Z/H3VkWVo59nzySJn/3XB9LLGdLe7jtjQoJDGmhiyzruAqelwv+bVf7sckEWTvwGbyPNiiQRs0Exi1m2hDQW2IwH/iHMd4l/LAY2Cq1875rpSTYF0SA1TAbE50eYcIZitvEvA3L0HAX/pBPUejqWcHVZ1dBxG0uf0n/ChWZs=
   on:
     tags: true
     condition: "$TRAVIS_RUBY_VERSION == 2.7"

--- a/dice_bag.gemspec
+++ b/dice_bag.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.authors = ["Andrew Smith", "Jordi Carres"]
   s.email = ["asmith@mdsol.com", "jcarres@mdsol.com"]
   s.summary = "Dice Bag is a library of rake tasks for configuring web apps in the style of The Twelve-Factor App. " \
-    "It also provides continuous integration tasks that rely on the configuration tasks."
+              "It also provides continuous integration tasks that rely on the configuration tasks."
   s.metadata = {
     "homepage_uri" => "https://github.com/mdsol/dice_bag",
     "changelog_uri" => "https://github.com/mdsol/dice_bag/blob/develop/CHANGELOG.md"

--- a/lib/dice_bag/available_templates.rb
+++ b/lib/dice_bag/available_templates.rb
@@ -16,11 +16,10 @@ module DiceBag
 
     class << self
       def gem_specs
-        @gem_specs ||= begin
+        @gem_specs ||=
           Gem::Specification.sort.each_with_object({}) do |spec, hsh|
             hsh[spec.name] = spec.full_gem_path
           end
-        end
       end
 
       def checker_within_given_gems?(checker, gem_names)

--- a/lib/dice_bag/template_helpers.rb
+++ b/lib/dice_bag/template_helpers.rb
@@ -32,7 +32,7 @@ module DiceBag
       cert.issuer = root_ca.subject # root CA is the issuer
       cert.public_key = PrivateKey.new(private_key.dup).public_key
       cert.not_before = Time.now
-      cert.not_after = cert.not_before + 1 * 365 * 24 * 60 * 60 # 1 years validity
+      cert.not_after = cert.not_before + (1 * 365 * 24 * 60 * 60) # 1 years validity
       ef = OpenSSL::X509::ExtensionFactory.new
       ef.subject_certificate = cert
       ef.issuer_certificate = root_ca
@@ -61,7 +61,7 @@ module DiceBag
       root_ca.issuer = root_ca.subject # root CA's are "self-signed"
       root_ca.public_key = root_key.public_key
       root_ca.not_before = Time.now
-      root_ca.not_after = root_ca.not_before + 2 * 365 * 24 * 60 * 60 # 2 years validity
+      root_ca.not_after = root_ca.not_before + (2 * 365 * 24 * 60 * 60) # 2 years validity
       ef = OpenSSL::X509::ExtensionFactory.new
       ef.subject_certificate = root_ca
       ef.issuer_certificate = root_ca


### PR DESCRIPTION
Due to a [security incident at Travis](https://travis-ci.community/t/security-bulletin/12081), all secrets must be rotated. This PR updates the rubygems API key.

@jcarres-mdsol 