### PR TITLE
Use keyword argument for ERB.new to suppress deprecated warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,9 @@ inherit_from: .rubocop_todo.yml
 AllCops:
   NewCops: enable
 
+Gemspec/RequireMFA:
+  Enabled: false
+
 Style/StringLiterals:
   Enabled: true
   EnforcedStyle: double_quotes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.6.1
 * Use keyword argument for ERB.new to suppress deprecated warnings.
+* Use default bundle path (`vendor/bundle`) when `Bundler.settings[:path]` returns nil.
 
 # 1.6.0
 * Drop support for Ruby 2.3 and 2.4.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.6.1
+* Use keyword argument for ERB.new to suppress deprecated warnings.
+
 # 1.6.0
 * Drop support for Ruby 2.3 and 2.4.
 

--- a/lib/dice_bag/project.rb
+++ b/lib/dice_bag/project.rb
@@ -4,6 +4,7 @@
 module DiceBag
   class Project
     DEFAULT_NAME = "project"
+    DEFAULT_BUNDLE_PATH = "vendor/bundle"
 
     # TODO: how to find the name of the project in non Rails apps?
     def self.name
@@ -22,8 +23,9 @@ module DiceBag
     end
 
     def self.templates_to_generate
+      bundle_path = (defined?(Bundler) && Bundler.settings[:path]) || DEFAULT_BUNDLE_PATH
       FileList.new("**/*.dice") do |fl|
-        fl.exclude(File.join(Bundler.settings[:path], "/**/*")) if defined?(Bundler) && Bundler.settings[:path]
+        fl.exclude(File.join(bundle_path, "/**/*"))
       end
     end
   end

--- a/lib/dice_bag/template_file.rb
+++ b/lib/dice_bag/template_file.rb
@@ -19,11 +19,6 @@ module DiceBag
     end
 
     def create_file(config_file, params)
-      # By passing "<>" we're trimming trailing newlines on lines that are
-      # nothing but ERB blocks (see documentation). This is useful for files
-      # like mauth_key where we want to control newlines carefully.
-      template = ERB.new(File.read(@file), nil, "<>")
-
       # templates expect a configured object
       configured = Configuration.new
       warning = Warning.new(@filename)
@@ -33,6 +28,19 @@ module DiceBag
 
       config_file.write(contents)
       puts "File '#{config_file.file}' created"
+    end
+
+    private
+
+    def template
+      # By passing "<>" we're trimming trailing newlines on lines that are
+      # nothing but ERB blocks (see documentation). This is useful for files
+      # like mauth_key where we want to control newlines carefully.
+      if ERB.instance_method(:initialize).parameters.assoc(:key) # Ruby 2.6+
+        ERB.new(File.read(@file), trim_mode: "<>")
+      else
+        ERB.new(File.read(@file), nil, "<>")
+      end
     end
   end
 end

--- a/lib/dice_bag/version.rb
+++ b/lib/dice_bag/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DiceBag
-  VERSION = "1.6.0"
+  VERSION = "1.6.1"
 end

--- a/spec/support/config/database.yml.dice
+++ b/spec/support/config/database.yml.dice
@@ -1,0 +1,4 @@
+development:
+  database: development
+  username: <%= configured.database_username || 'root' %>
+  password: <%= configured.database_password %>

--- a/spec/template_file_spec.rb
+++ b/spec/template_file_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dice_bag/project"
+require "dice_bag/template_file"
+
+RSpec.describe DiceBag::TemplateFile do
+  let(:file_name) { "config/database.yml" }
+  let(:template_name) { "#{file_name}.dice" }
+  let(:template_file) { DiceBag::TemplateFile.new(template_name) }
+  let(:config_file) { double(file: file_name) }
+  let(:params) { { deploy: true } }
+
+  before do
+    allow(ENV).to receive(:[]).with("DATABASE_USERNAME").and_return("alice")
+    allow(ENV).to receive(:[]).with("DATABASE_PASSWORD").and_return("xyzzy")
+    allow(DiceBag::Project).to receive(:root).and_return(File.join(__dir__, "support"))
+  end
+
+  it "writes to configuration file" do
+    expect(config_file)
+      .to receive(:write).with("development:\n  database: development\n  username: alice\n  password: xyzzy\n")
+    template_file.create_file(config_file, params)
+  end
+end


### PR DESCRIPTION
### keyword argument for ERB.new

To suppress these warnings:
> warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
> warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead. 

https://github.com/voormedia/rails-erd/pull/297

### Use default bundle path 

In recent versions of Bundler, `Bundler.settings[:path]` returns nil if you only set `BUNDLE_DEPLOYMENT=true` so dice_bag is a little too greedy...

> File '/home/app/web/config/database.yml' created
>   :
> File '/home/app/web/vendor/bundle/ruby/3.0.0/gems/dice_bag-1.6.0/lib/dice_bag/templates/databases/mysql.yml' created
> File '/home/app/web/vendor/bundle/ruby/3.0.0/gems/dice_bag-1.6.0/lib/dice_bag/templates/databases/postgres.yml' created

@mdsol/architecture-enablement @jcarres-mdsol 